### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Data/Exists.purs
+++ b/src/Data/Exists.purs
@@ -26,6 +26,8 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | ```
 foreign import data Exists :: (Type -> Type) -> Type
 
+type role Exists representational
+
 -- | The `mkExists` function is used to introduce a value of type `Exists f`, by providing a value of
 -- | type `f a`, for some type `a` which will be hidden in the existentially-quantified type.
 -- |


### PR DESCRIPTION
This allows terms of type `Exists f` to be coerced to type `Effect g` when `Coercible f g` holds, hence allowing the zero cost `coerce` instead of `runExists (wrap >>> mkExists)` and `runExists (unwrap >>> mkExists)` to introduce and eliminate newtypes with an existentially quantified parameter.