### PR TITLE
Generalize `Exists` to hold non-`Type`-kinded types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 
 New features:
 - Added roles declarations to allow safe coercions (#9) 
+- Generalized `Exists` to hold non-`Type`-kinded types (#14)
 
 Bugfixes:
 

--- a/src/Data/Exists.purs
+++ b/src/Data/Exists.purs
@@ -2,7 +2,7 @@ module Data.Exists where
 
 import Unsafe.Coerce (unsafeCoerce)
 
--- | This type constructor can be used to existentially quantify over a type of kind `Type`.
+-- | This type constructor can be used to existentially quantify over a type.
 -- |
 -- | Specifically, the type `Exists f` is isomorphic to the existential type `exists a. f a`.
 -- |
@@ -24,7 +24,7 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | ```purescript
 -- | type Stream a = Exists (StreamF a)
 -- | ```
-foreign import data Exists :: (Type -> Type) -> Type
+foreign import data Exists :: forall k. (k -> Type) -> Type
 
 type role Exists representational
 

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -1,3 +1,0 @@
-exports.length = function (a) {
-    return a.length;
-};

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -1,0 +1,3 @@
+exports.length = function (a) {
+    return a.length;
+};

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -12,8 +12,6 @@ data Tuple a b = Tuple a b
 snd :: forall a b. Tuple a b -> b
 snd (Tuple _ b) = b
 
-foreign import length :: forall a. Array a -> Int
-
 data StreamF a s = StreamF s (s -> Tuple s a)
 
 type Stream a = Exists (StreamF a)
@@ -27,18 +25,24 @@ head = runExists head'
   head' :: forall s. StreamF a s -> a
   head' (StreamF s f) = snd (f s)
 
+data Maybe a = Nothing | Just a
+
+count :: forall a. Maybe a -> Int
+count Nothing = 0
+count _ = 1
+
 data FooF f = FooF (forall a. f a -> Int) (f String)
 
 type Foo = Exists FooF
 
 foo :: Foo
-foo = mkExists $ FooF length ["hello", "world"]
+foo = mkExists $ FooF count (Just "test")
 
 x :: Int
 x = runExists runFooF foo
   where
   runFooF :: forall f. FooF f -> Int
-  runFooF (FooF f strings) = f strings
+  runFooF (FooF f fStr) = f fStr
 
 main :: Effect Unit
 main = logShow $ head nats

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -12,6 +12,8 @@ data Tuple a b = Tuple a b
 snd :: forall a b. Tuple a b -> b
 snd (Tuple _ b) = b
 
+foreign import length :: forall a. Array a -> Int
+
 data StreamF a s = StreamF s (s -> Tuple s a)
 
 type Stream a = Exists (StreamF a)
@@ -24,6 +26,19 @@ head = runExists head'
   where
   head' :: forall s. StreamF a s -> a
   head' (StreamF s f) = snd (f s)
+
+data FooF f = FooF (forall a. f a -> Int) (f String)
+
+type Foo = Exists FooF
+
+foo :: Foo
+foo = mkExists $ FooF length ["hello", "world"]
+
+x :: Int
+x = runExists runFooF foo
+  where
+  runFooF :: forall f. FooF f -> Int
+  runFooF (FooF f strings) = f strings
 
 main :: Effect Unit
 main = logShow $ head nats


### PR DESCRIPTION
**Description of the change**

With polymorphic kinds, `Exists` can be generalized to quantify over types of kind other than `Type`. I don't believe there's any disadvantage to doing so.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
